### PR TITLE
✅ Improving package.json scripts for testing to include coverage reports

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "test": "react-scripts test --detectOpenHandles",
+    "test": "react-scripts test --coverage --detectOpenHandles --watchAll ",
+    "test:total": "react-scripts test --coverage --coverageReporters='text-summary' --detectOpenHandles --watchAll",
     "build": "react-scripts build",
     "lint": "eslint src/**/*.js",
     "lint:fix": "eslint src/**/*.js --fix",
@@ -39,6 +40,12 @@
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(axios)/)"
+    ],
+    "collectCoverageFrom": [
+      "!<rootDir>/node_modules/",
+      "!<rootDir>/src/index.js",
+      "!<rootDir>/src/serviceWorker.js",
+     "!<rootDir>/src/reportWebVitals.js"
     ]
   },
   "browserslist": {


### PR DESCRIPTION
- Added --coverage and --watchAll for the test command script
- Added a new 'test:total' script which included --coverageReporters='text-summary' so I can see the total coverage for the tests
- Changed jest config so it ignores files that I dont need to test