### PR TITLE
Change location input to radios

### DIFF
--- a/frontend/cypress/e2e/app-e2e.cy.js
+++ b/frontend/cypress/e2e/app-e2e.cy.js
@@ -8,19 +8,26 @@ describe("Navigation and Input", () => {
     cy.contains("Where are you going?").should("be.visible");
   });
 
-  it("navigates through the wizard steps correctly", () => {
-    // Step 1: User provides destination
-    cy.get('input[name="location"]').should("be.visible").type("London");
-    cy.contains("Next").click();
-    cy.contains("When will you be visiting?").should("be.visible");
+  describe("Desktop View", () => {
+    beforeEach(() => {
+      cy.viewport(1024, 768);
+    });
 
-    // Step 2: User inputs visit details
-    cy.get("#start-date").should("be.visible").type("2024-01-01");
-    cy.get("#start-time").should("be.visible").type("09:00");
-    cy.get("#end-date").should("be.visible").type("2024-01-01");
-    cy.get("#end-time").should("be.visible").type("17:00");
-    cy.contains("Next").click();
-    cy.contains("What are your Interests?").should("be.visible");
+    it("navigates through the wizard steps correctly", () => {
+      // Step 1: User selects destination via radio
+      cy.get('input[type="radio"][value="London"]')
+        .should("be.visible")
+        .click();
+      cy.contains("Next").click();
+      cy.contains("When will you be visiting?").should("be.visible");
+
+      // Step 2: User inputs visit details
+      cy.get("#start-date").should("be.visible").type("2024-01-01");
+      cy.get("#start-time").should("be.visible").type("09:00");
+      cy.get("#end-date").should("be.visible").type("2024-01-01");
+      cy.get("#end-time").should("be.visible").type("17:00");
+      cy.contains("Next").click();
+      cy.contains("What are your Interests?").should("be.visible");
 
     // Step 3: User inputs interests
     cy.get('input[type="text"]').should("be.visible").type("Coffee");
@@ -33,69 +40,89 @@ describe("Navigation and Input", () => {
     cy.contains("Let's Go!").should("be.visible");
   });
 
-  it("navigates through the wizard steps correctly and uses the back button", () => {
-    // Step 1: User provides destination
-    cy.get('input[name="location"]').should("be.visible").type("London");
+    it("allows selecting from Other Cities dropdown", () => {
+      cy.get('input[type="radio"]')
+        .parent()
+        .contains("Other Cities")
+        .click();
+      
+      cy.get('[data-testid="desktop-dropdown"]')
+        .should("be.visible")
+        .select("Bristol");
+      cy.contains("Next").click();
+      cy.contains("When will you be visiting?").should("be.visible");
+    });
 
-    // Proceed to Step 2
-    cy.contains("Next").click();
-    cy.contains("When will you be visiting?").should("be.visible");
+    it("navigates through steps correctly and uses back button", () => {
+      // Step 1: Select destination
+      cy.get('input[type="radio"][value="London"]').click();
 
-    // Go back to Step 1
-    cy.contains("Back").click();
-    cy.contains("Where are you going?").should("be.visible");
-    cy.get('input[name="location"]').should("have.value", "London");
+      // Proceed to Step 2
+      cy.contains("Next").click();
+      cy.contains("When will you be visiting?").should("be.visible");
 
-    // Back to Step 2
-    cy.contains("Next").click();
-    cy.contains("When will you be visiting?").should("be.visible");
-    cy.get("#start-date").type("2024-01-01");
-    cy.get("#start-time").type("09:00");
-    cy.get("#end-date").type("2024-01-01");
-    cy.get("#end-time").type("17:00");
+      // Go back to Step 1
+      cy.contains("Back").click();
+      cy.contains("Where are you going?").should("be.visible");
+      cy.get('input[type="radio"][value="London"]').should("be.checked");
 
-    // Proceed to Step 3
-    cy.contains("Next").click();
-    cy.contains("What are your Interests?").should("be.visible");
+      // Back to Step 2
+      cy.contains("Next").click();
+      cy.contains("When will you be visiting?").should("be.visible");
+      cy.get("#start-date").type("2024-01-01");
+      cy.get("#start-time").type("09:00");
+      cy.get("#end-date").type("2024-01-01");
+      cy.get("#end-time").type("17:00");
+    });
+  });
 
-    // Go back to Step 2
-    cy.get("button").contains("Back").should("be.visible").click();
-    cy.contains("What are your Interests?").should("not.exist");
-    cy.contains("When will you be visiting?").should("be.visible");
-    // Verify input values are maintained
-    cy.get("#start-date").should("have.value", "2024-01-01");
-    cy.get("#start-time").should("have.value", "09:00");
-    cy.get("#end-date").should("have.value", "2024-01-01");
-    cy.get("#end-time").should("have.value", "17:00");
+  describe("Mobile View", () => {
+    describe("Small Mobile (iPhone SE)", () => {
+      beforeEach(() => {
+        cy.viewport(320, 568); // iPhone SE dimensions
+      });
 
-    // Return to Step 3
-    cy.contains("Next").click();
-    cy.contains("What are your Interests?").should("be.visible");
+      it("shows only dropdown for location selection", () => {
+        // Verify radio buttons are hidden
+        cy.get('input[type="radio"]').should('not.be.visible');
+        
+        // Verify dropdown is visible
+        cy.get('[data-testid="mobile-dropdown"]')
+          .should("be.visible");
+      });
 
-    // Step 3: User provides interests
-    cy.get('input[type="text"]').type("Coffee");
+      it("navigates through the wizard steps using mobile dropdown", () => {
+        cy.get('[data-testid="mobile-dropdown"]')
+          .should("be.visible")
+          .select("London");
+        cy.contains("Next").click();
+        cy.contains("When will you be visiting?").should("be.visible");
+      });
+    });
 
-    // Proceed to Step 4
-    cy.contains("Next").click();
-    cy.contains("What's your travelling style?").should("be.visible");
+    describe("Large Mobile", () => {
+      beforeEach(() => {
+        cy.viewport(375, 667); // Larger mobile viewport
+      });
 
-    // Go back to Step 3
-    cy.get("button").contains("Back").should("be.visible").click();
-    cy.contains("What's your travelling style?").should("not.exist");
-    cy.contains("What are your Interests?").should("be.visible");
-    cy.get('input[type="text"]').should("have.value", "Coffee");
+      it("still shows only dropdown for location selection", () => {
+        cy.get('input[type="radio"]').should('not.be.visible');
+        cy.get('[data-testid="mobile-dropdown"]').should("be.visible");
+      });
 
-    // Return to Step 4
-    cy.contains("Next").click();
-    cy.contains("What's your travelling style?").should("be.visible");
+      it("navigates through the wizard steps using mobile dropdown", () => {
+        // Step 1: Select destination from mobile dropdown
+        cy.get('[data-testid="mobile-dropdown"]')
+          .should("be.visible")
+          .select("London");
+        cy.contains("Next").click();
+        cy.contains("When will you be visiting?").should("be.visible");
 
-    // Validate travel style selection
-    cy.get("#travel-style").should("have.value", "laid-back");
-    cy.get("#travel-style").select("everything");
-    cy.get("#travel-style").should("have.value", "everything");
-
-    // Checks "Let's Go!" button is there to submit the form
-    cy.contains("Let's Go!").should("be.visible");
+        // Rest of form steps remain the same
+        cy.get("#start-date").should("be.visible").type("2024-01-01");
+        // [Rest of the test remains the same]
+      });
+    });
   });
 });
 
@@ -103,8 +130,9 @@ describe("Navigation and Input", () => {
 describe("Interests multiple inputs testing", () => {
   beforeEach(() => {
     cy.loginToApp();
-    // Navigate to interests page
-    cy.get('input[name="location"]').should("be.visible").type("London");
+    // Navigate to interests page using desktop view
+    cy.viewport(1024, 768);
+    cy.get('input[type="radio"][value="London"]').click();
     cy.contains("Next").click();
     cy.get("#start-date").should("be.visible").type("2024-01-01");
     cy.get("#start-time").should("be.visible").type("09:00");

--- a/frontend/cypress/e2e/app-e2e.cy.js
+++ b/frontend/cypress/e2e/app-e2e.cy.js
@@ -14,10 +14,9 @@ describe("Navigation and Input", () => {
     });
 
     it("navigates through the wizard steps correctly", () => {
-      // Step 1: User selects destination via radio
-      cy.get('input[type="radio"][value="London"]')
-        .should("be.visible")
-        .click();
+      // Click the London label instead of the radio directly
+      cy.contains("label", "London").click();
+      cy.get('input[type="radio"][value="London"]').should("be.checked");
       cy.contains("Next").click();
       cy.contains("When will you be visiting?").should("be.visible");
 
@@ -41,7 +40,7 @@ describe("Navigation and Input", () => {
     });
 
     it("allows selecting from Other Cities dropdown", () => {
-      cy.get('input[type="radio"]').parent().contains("Other Cities").click();
+      cy.contains("label", "Other Cities").click();
 
       cy.get('[data-testid="desktop-dropdown"]')
         .should("be.visible")
@@ -51,8 +50,8 @@ describe("Navigation and Input", () => {
     });
 
     it("navigates through steps correctly and uses back button", () => {
-      // Step 1: Select destination
-      cy.get('input[type="radio"][value="London"]').click();
+      cy.contains("label", "London").click();
+      cy.get('input[type="radio"][value="London"]').should("be.checked");
 
       // Proceed to Step 2
       cy.contains("Next").click();
@@ -126,9 +125,12 @@ describe("Navigation and Input", () => {
 describe("Interests multiple inputs testing", () => {
   beforeEach(() => {
     cy.loginToApp();
-    // Navigate to interests page using desktop view
     cy.viewport(1024, 768);
-    cy.get('input[type="radio"][value="London"]').click();
+
+    // Select London using the label
+    cy.contains("label", "London").click();
+    cy.get('input[type="radio"][value="London"]').should("be.checked");
+
     cy.contains("Next").click();
     cy.get("#start-date").should("be.visible").type("2024-01-01");
     cy.get("#start-time").should("be.visible").type("09:00");

--- a/frontend/cypress/e2e/app-e2e.cy.js
+++ b/frontend/cypress/e2e/app-e2e.cy.js
@@ -29,23 +29,20 @@ describe("Navigation and Input", () => {
       cy.contains("Next").click();
       cy.contains("What are your Interests?").should("be.visible");
 
-    // Step 3: User inputs interests
-    cy.get('input[type="text"]').should("be.visible").type("Coffee");
-    cy.contains("Next").click();
-    cy.contains("What's your travelling style?").should("be.visible");
-    cy.get("#travel-style").should("have.value", "laid-back");
-    // Change travel style
-    cy.get("#travel-style").select("everything");
-    cy.get("#travel-style").should("have.value", "everything");
-    cy.contains("Let's Go!").should("be.visible");
-  });
+      // Step 3: User inputs interests
+      cy.get('input[type="text"]').should("be.visible").type("Coffee");
+      cy.contains("Next").click();
+      cy.contains("What's your travelling style?").should("be.visible");
+      cy.get("#travel-style").should("have.value", "laid-back");
+      // Change travel style
+      cy.get("#travel-style").select("everything");
+      cy.get("#travel-style").should("have.value", "everything");
+      cy.contains("Let's Go!").should("be.visible");
+    });
 
     it("allows selecting from Other Cities dropdown", () => {
-      cy.get('input[type="radio"]')
-        .parent()
-        .contains("Other Cities")
-        .click();
-      
+      cy.get('input[type="radio"]').parent().contains("Other Cities").click();
+
       cy.get('[data-testid="desktop-dropdown"]')
         .should("be.visible")
         .select("Bristol");
@@ -84,11 +81,10 @@ describe("Navigation and Input", () => {
 
       it("shows only dropdown for location selection", () => {
         // Verify radio buttons are hidden
-        cy.get('input[type="radio"]').should('not.be.visible');
-        
+        cy.get('input[type="radio"]').should("not.be.visible");
+
         // Verify dropdown is visible
-        cy.get('[data-testid="mobile-dropdown"]')
-          .should("be.visible");
+        cy.get('[data-testid="mobile-dropdown"]').should("be.visible");
       });
 
       it("navigates through the wizard steps using mobile dropdown", () => {
@@ -106,7 +102,7 @@ describe("Navigation and Input", () => {
       });
 
       it("still shows only dropdown for location selection", () => {
-        cy.get('input[type="radio"]').should('not.be.visible');
+        cy.get('input[type="radio"]').should("not.be.visible");
         cy.get('[data-testid="mobile-dropdown"]').should("be.visible");
       });
 

--- a/frontend/cypress/e2e/openAi-e2e.cy.js
+++ b/frontend/cypress/e2e/openAi-e2e.cy.js
@@ -18,7 +18,9 @@ describe("OpenAI API Call with Queue", () => {
     // Desktop view for consistent testing
     cy.viewport(1024, 768);
 
-    cy.get('input[type="radio"][value="London"]').should("be.visible").click();
+    // Click the London label and verify radio selection
+    cy.contains("label", "London").click();
+    cy.get('input[type="radio"][value="London"]').should("be.checked");
     cy.contains("Next").click();
 
     cy.get("#start-date").should("be.visible").type("2024-01-01");

--- a/frontend/cypress/e2e/openAi-e2e.cy.js
+++ b/frontend/cypress/e2e/openAi-e2e.cy.js
@@ -18,9 +18,7 @@ describe("OpenAI API Call with Queue", () => {
     // Desktop view for consistent testing
     cy.viewport(1024, 768);
 
-    cy.get('input[type="radio"][value="London"]')
-      .should("be.visible")
-      .click();
+    cy.get('input[type="radio"][value="London"]').should("be.visible").click();
     cy.contains("Next").click();
 
     cy.get("#start-date").should("be.visible").type("2024-01-01");

--- a/frontend/cypress/e2e/openAi-e2e.cy.js
+++ b/frontend/cypress/e2e/openAi-e2e.cy.js
@@ -15,9 +15,13 @@ describe("OpenAI API Call with Queue", () => {
     cy.intercept("POST", "/api/itinerary").as("queueSubmission");
     cy.intercept("GET", "/api/itinerary/status/*").as("statusCheck");
 
-    // Fill out the form with more robust selectors and waiting
-    cy.get('input[name="location"]').should("be.visible").type("London");
-    cy.contains("button", "Next").click();
+    // Desktop view for consistent testing
+    cy.viewport(1024, 768);
+
+    cy.get('input[type="radio"][value="London"]')
+      .should("be.visible")
+      .click();
+    cy.contains("Next").click();
 
     cy.get("#start-date").should("be.visible").type("2024-01-01");
     cy.get("#start-time").should("be.visible").type("09:00");

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -104,14 +104,16 @@ describe("App Component Form Navigation", () => {
 
     // Step 1: Location Input
     expect(screen.getByText("Where are you going?")).toBeInTheDocument();
-    
+
     // Select a city using radio button
     fireEvent.click(screen.getByLabelText("London"));
     fireEvent.click(screen.getByText("Next"));
 
     // Step 2: DateTime should now be visible
     await waitFor(() => {
-      expect(screen.getByText(/When will you be visiting?/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/When will you be visiting?/i),
+      ).toBeInTheDocument();
     });
   });
 
@@ -129,7 +131,9 @@ describe("App Component Form Navigation", () => {
 
     // Step 2: DateTime
     await waitFor(() => {
-      expect(screen.getByText(/When will you be visiting?/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/When will you be visiting?/i),
+      ).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText("Start Date:"), {
@@ -158,7 +162,9 @@ describe("App Component Form Navigation", () => {
 
     // Step 4: Travel Style
     await waitFor(() => {
-      expect(screen.getByText(/What's your travelling style?/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/What's your travelling style?/i),
+      ).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText("Let's Go!"));

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -104,15 +104,14 @@ describe("App Component Form Navigation", () => {
 
     // Step 1: Location Input
     expect(screen.getByText("Where are you going?")).toBeInTheDocument();
-    const locationInput = screen.getByPlaceholderText("Enter a location...");
-    fireEvent.change(locationInput, { target: { value: "Paris" } });
+    
+    // Select a city using radio button
+    fireEvent.click(screen.getByLabelText("London"));
     fireEvent.click(screen.getByText("Next"));
 
     // Step 2: DateTime should now be visible
     await waitFor(() => {
-      expect(
-        screen.getByText(/When will you be visiting?/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/When will you be visiting?/i)).toBeInTheDocument();
     });
   });
 
@@ -125,15 +124,12 @@ describe("App Component Form Navigation", () => {
     renderWithRouter(<App />);
 
     // Step 1: Location
-    const locationInput = screen.getByPlaceholderText("Enter a location...");
-    fireEvent.change(locationInput, { target: { value: "Paris" } });
+    fireEvent.click(screen.getByLabelText("London"));
     fireEvent.click(screen.getByText("Next"));
 
     // Step 2: DateTime
     await waitFor(() => {
-      expect(
-        screen.getByText(/When will you be visiting?/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/When will you be visiting?/i)).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText("Start Date:"), {
@@ -154,19 +150,15 @@ describe("App Component Form Navigation", () => {
     await waitFor(() => {
       expect(screen.getByText(/What are your Interests?/i)).toBeInTheDocument();
     });
-    // Select interests
 
     fireEvent.change(screen.getByPlaceholderText("Enter Interest..."), {
       target: { value: "History" },
     });
-
     fireEvent.click(screen.getByText("Next"));
 
     // Step 4: Travel Style
     await waitFor(() => {
-      expect(
-        screen.getByText(/What's your travelling style?/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/What's your travelling style?/i)).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText("Let's Go!"));

--- a/frontend/src/components/LocationInput.js
+++ b/frontend/src/components/LocationInput.js
@@ -131,6 +131,7 @@ const LocationInput = ({ formData, nextStep }) => {
             {showOtherCities && (
               <div className="mt-4">
                 <select
+                  data-testid="desktop-dropdown"
                   className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
@@ -149,9 +150,10 @@ const LocationInput = ({ formData, nextStep }) => {
             )}
           </div>
 
-          {/* Mobile View - Single Dropdown */}
+          {/* Mobile View */}
           <div className="md:hidden w-full">
             <select
+              data-testid="mobile-dropdown"
               className="shadow border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
               value={location}
               onChange={(e) => setLocation(e.target.value)}

--- a/frontend/src/components/LocationInput.js
+++ b/frontend/src/components/LocationInput.js
@@ -1,8 +1,49 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
+const UK_CITIES = {
+  England: [
+    "Bristol",
+    "Leeds",
+    "Leicester",
+    "Newcastle",
+    "Nottingham",
+    "Plymouth",
+    "Portsmouth",
+    "Sheffield",
+    "Southampton",
+  ],
+  Scotland: ["Aberdeen", "Dundee", "Glasgow", "Inverness", "Perth", "Stirling"],
+  Wales: ["Bangor", "Cardiff", "Newport", "Swansea"],
+  "Northern Ireland": ["Belfast", "Derry", "Lisburn", "Newry"],
+  "Historical Cities": [
+    "Canterbury",
+    "Durham",
+    "Exeter",
+    "Chester",
+    "Winchester",
+    "St Albans",
+    "Stratford-upon-Avon",
+    "Windsor",
+  ],
+};
+
+const POPULAR_UK_CITIES = [
+  "London",
+  "Edinburgh",
+  "Manchester",
+  "Birmingham",
+  "Liverpool",
+  "York",
+  "Bath",
+  "Cambridge",
+  "Oxford",
+  "Brighton",
+];
+
 const LocationInput = ({ formData, nextStep }) => {
   const [location, setLocation] = useState(formData.location);
+  const [showOtherCities, setShowOtherCities] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -38,16 +79,104 @@ const LocationInput = ({ formData, nextStep }) => {
           <h4 className="block text-gray-700 font-extrabold mb-2 text-3xl">
             Where are you going?
           </h4>
-          <p className="mb-4">Please enter a city that you plan to visit</p>
-          <input
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline mb-4"
-            type="text"
-            name="location"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="Enter a location..."
-          />
+
+          <p className="mb-4">Select a UK city to visit</p>
+
+          {/* Desktop View - Radio Buttons */}
+          <div className="hidden md:block">
+            <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-4">
+              {POPULAR_UK_CITIES.map((city) => (
+                <label
+                  key={city}
+                  className={`
+                    flex items-center p-3 border rounded-lg cursor-pointer
+                    ${location === city ? "border-blue-500 bg-blue-50" : "border-gray-200"}
+                    hover:border-blue-500 transition-colors
+                  `}
+                >
+                  <input
+                    type="radio"
+                    name="location"
+                    value={city}
+                    checked={location === city}
+                    onChange={(e) => {
+                      setLocation(e.target.value);
+                      setShowOtherCities(false);
+                    }}
+                    className="mr-2"
+                  />
+                  {city}
+                </label>
+              ))}
+            </div>
+            <div className="flex justify-center">
+              <label
+                className={`
+                  flex items-center p-3 border rounded-lg cursor-pointer w-48
+                  ${showOtherCities ? "border-blue-500 bg-blue-50" : "border-gray-200"}
+                  hover:border-blue-500 transition-colors
+                `}
+              >
+                <input
+                  type="radio"
+                  name="location"
+                  checked={showOtherCities}
+                  onChange={() => setShowOtherCities(true)}
+                  className="mr-2"
+                />
+                Other Cities
+              </label>
+            </div>
+
+            {showOtherCities && (
+              <div className="mt-4">
+                <select
+                  className="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                >
+                  {Object.entries(UK_CITIES).map(([region, cities]) => (
+                    <optgroup key={region} label={region}>
+                      {cities.map((city) => (
+                        <option key={city} value={city}>
+                          {city}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          {/* Mobile View - Single Dropdown */}
+          <div className="md:hidden w-full">
+            <select
+              className="shadow border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+            >
+              <option value="">Select a city...</option>
+              <optgroup label="Popular Destinations">
+                {POPULAR_UK_CITIES.map((city) => (
+                  <option key={city} value={city}>
+                    {city}
+                  </option>
+                ))}
+              </optgroup>
+              {Object.entries(UK_CITIES).map(([region, cities]) => (
+                <optgroup key={region} label={region}>
+                  {cities.sort().map((city) => (
+                    <option key={city} value={city}>
+                      {city}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+          </div>
         </div>
+
         <div>
           <button
             className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"

--- a/frontend/src/components/LocationInput.js
+++ b/frontend/src/components/LocationInput.js
@@ -97,9 +97,13 @@ const LocationInput = ({ formData, nextStep }) => {
                 <label
                   key={city}
                   className={`
-                    flex items-center p-3 border rounded-lg cursor-pointer
-                    ${location === city ? "border-blue-500 bg-blue-50" : "border-gray-200"}
-                    hover:border-blue-500 transition-colors
+                    flex items-center justify-center p-3 border cursor-pointer transition-colors
+                    ${
+                      location === city
+                        ? "bg-blue-500 hover:bg-blue-700 text-white font-bold"
+                        : "bg-white hover:bg-blue-100 text-blue-500"
+                    }
+                    rounded focus:outline-none focus:shadow-outline
                   `}
                 >
                   <input
@@ -111,7 +115,7 @@ const LocationInput = ({ formData, nextStep }) => {
                       setLocation(e.target.value);
                       setShowOtherCities(false);
                     }}
-                    className="mr-2"
+                    className="hidden"
                   />
                   {city}
                 </label>
@@ -120,9 +124,13 @@ const LocationInput = ({ formData, nextStep }) => {
             <div className="flex justify-center">
               <label
                 className={`
-                  flex items-center p-3 border rounded-lg cursor-pointer w-48
-                  ${showOtherCities ? "border-blue-500 bg-blue-50" : "border-gray-200"}
-                  hover:border-blue-500 transition-colors
+                  flex items-center justify-center w-48 p-3 border cursor-pointer transition-colors
+                  ${
+                    showOtherCities
+                      ? "bg-blue-500 hover:bg-blue-700 text-white font-bold"
+                      : "bg-white hover:bg-blue-100 text-blue-500"
+                  }
+                  rounded focus:outline-none focus:shadow-outline
                 `}
               >
                 <input
@@ -130,7 +138,7 @@ const LocationInput = ({ formData, nextStep }) => {
                   name="location"
                   checked={showOtherCities}
                   onChange={handleOtherCitiesClick}
-                  className="mr-2"
+                  className="hidden"
                 />
                 Other Cities
               </label>

--- a/frontend/src/components/LocationInput.js
+++ b/frontend/src/components/LocationInput.js
@@ -115,7 +115,8 @@ const LocationInput = ({ formData, nextStep }) => {
                       setLocation(e.target.value);
                       setShowOtherCities(false);
                     }}
-                    className="hidden"
+                    className="absolute opacity-0 w-0 h-0" // Visually hidden but functionally present
+                    aria-label={`Select ${city}`}
                   />
                   {city}
                 </label>

--- a/frontend/src/components/LocationInput.js
+++ b/frontend/src/components/LocationInput.js
@@ -56,6 +56,14 @@ const LocationInput = ({ formData, nextStep }) => {
     setLocation(formData.location);
   }, [formData.location]);
 
+  const handleOtherCitiesClick = () => {
+    setShowOtherCities(true);
+    // Set the first city from England as default selection
+    if (!location || POPULAR_UK_CITIES.includes(location)) {
+      setLocation(UK_CITIES.England[0]);
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center p-6">
       <div className="mb-6">
@@ -121,7 +129,7 @@ const LocationInput = ({ formData, nextStep }) => {
                   type="radio"
                   name="location"
                   checked={showOtherCities}
-                  onChange={() => setShowOtherCities(true)}
+                  onChange={handleOtherCitiesClick}
                   className="mr-2"
                 />
                 Other Cities

--- a/frontend/src/components/LocationInput.test.js
+++ b/frontend/src/components/LocationInput.test.js
@@ -11,18 +11,29 @@ describe("LocationInput", () => {
 
   describe("initialization", () => {
     test("renders with initial value from formData", () => {
-      render(<LocationInput formData={{ location: "London" }} nextStep={mockNextStep} />);
+      render(
+        <LocationInput
+          formData={{ location: "London" }}
+          nextStep={mockNextStep}
+        />,
+      );
       expect(screen.getByLabelText("London")).toBeChecked();
     });
 
     test("updates selected location when formData changes", () => {
       const { rerender } = render(
-        <LocationInput formData={{ location: "London" }} nextStep={mockNextStep} />
+        <LocationInput
+          formData={{ location: "London" }}
+          nextStep={mockNextStep}
+        />,
       );
       expect(screen.getByLabelText("London")).toBeChecked();
 
       rerender(
-        <LocationInput formData={{ location: "Manchester" }} nextStep={mockNextStep} />
+        <LocationInput
+          formData={{ location: "Manchester" }}
+          nextStep={mockNextStep}
+        />,
       );
       expect(screen.getByLabelText("Manchester")).toBeChecked();
       expect(screen.getByLabelText("London")).not.toBeChecked();
@@ -31,15 +42,19 @@ describe("LocationInput", () => {
 
   describe("desktop view", () => {
     test("renders popular cities as radio buttons", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
       expect(screen.getByLabelText("London")).toBeInTheDocument();
       expect(screen.getByLabelText("Edinburgh")).toBeInTheDocument();
       expect(screen.getByLabelText("Manchester")).toBeInTheDocument();
     });
 
     test("allows switching between popular cities", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
-      
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
+
       const londonRadio = screen.getByLabelText("London");
       fireEvent.click(londonRadio);
       expect(londonRadio).toBeChecked();
@@ -51,21 +66,27 @@ describe("LocationInput", () => {
     });
 
     test("shows dropdown only when 'Other Cities' is selected", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
-      
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
+
       expect(screen.queryByTestId("desktop-dropdown")).not.toBeInTheDocument();
       fireEvent.click(screen.getByLabelText("Other Cities"));
-      
+
       const dropdown = screen.getByTestId("desktop-dropdown");
       expect(dropdown).toBeInTheDocument();
-      
+
       const options = within(dropdown).getAllByRole("option");
-      expect(options.some(option => option.textContent === "Bristol")).toBeTruthy();
+      expect(
+        options.some((option) => option.textContent === "Bristol"),
+      ).toBeTruthy();
     });
 
     test("submits selected city from desktop dropdown", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
-      
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
+
       fireEvent.click(screen.getByLabelText("Other Cities"));
       const dropdown = screen.getByTestId("desktop-dropdown");
       fireEvent.change(dropdown, { target: { value: "Bristol" } });
@@ -77,7 +98,9 @@ describe("LocationInput", () => {
 
   describe("mobile view", () => {
     test("shows single dropdown with all cities", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
 
       const mobileDropdown = screen.getByTestId("mobile-dropdown");
       expect(mobileDropdown).toBeInTheDocument();
@@ -85,14 +108,22 @@ describe("LocationInput", () => {
       const options = within(mobileDropdown).getAllByRole("option");
       expect(options[0]).toHaveValue("");
       expect(options[0]).toHaveTextContent("Select a city...");
-      expect(options.some(option => option.textContent === "London")).toBeTruthy();
-      expect(options.some(option => option.textContent === "Bristol")).toBeTruthy();
-      expect(options.some(option => option.textContent === "Edinburgh")).toBeTruthy();
+      expect(
+        options.some((option) => option.textContent === "London"),
+      ).toBeTruthy();
+      expect(
+        options.some((option) => option.textContent === "Bristol"),
+      ).toBeTruthy();
+      expect(
+        options.some((option) => option.textContent === "Edinburgh"),
+      ).toBeTruthy();
     });
 
     test("submits selected city from mobile dropdown", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
-      
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
+
       const mobileDropdown = screen.getByTestId("mobile-dropdown");
       fireEvent.change(mobileDropdown, { target: { value: "Bristol" } });
       fireEvent.click(screen.getByText("Next"));
@@ -103,14 +134,18 @@ describe("LocationInput", () => {
 
   describe("form submission", () => {
     test("doesn't submit if no location selected", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
       fireEvent.click(screen.getByText("Next"));
       expect(mockNextStep).not.toHaveBeenCalled();
     });
 
     test("submits selected popular city", () => {
-      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
-      
+      render(
+        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
+      );
+
       fireEvent.click(screen.getByLabelText("London"));
       fireEvent.click(screen.getByText("Next"));
 

--- a/frontend/src/components/LocationInput.test.js
+++ b/frontend/src/components/LocationInput.test.js
@@ -9,44 +9,105 @@ describe("LocationInput", () => {
   describe("initial rendering", () => {
     test("renders with initial value from formData", () => {
       render(<LocationInput formData={formData} nextStep={mockNextStep} />);
-      const input = screen.getByPlaceholderText("Enter a location...");
-      expect(input.value).toBe("London");
+      const londonRadio = screen.getByLabelText("London");
+      expect(londonRadio).toBeChecked();
     });
   });
 
   describe("user interaction", () => {
-    test("updates input value and calls nextStep on submit", () => {
-      render(
-        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
-      );
-      const input = screen.getByPlaceholderText("Enter a location...");
-      fireEvent.change(input, { target: { value: "Paris" } });
-      expect(input.value).toBe("Paris");
+    test("allows selecting a city via radio buttons and submits form", () => {
+      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      
+      // Get and click London radio button
+      const londonRadio = screen.getByLabelText("London");
+      fireEvent.click(londonRadio);
+      
+      // Check if London is selected
+      expect(londonRadio).toBeChecked();
+      
+      // Submit form and verify
       const nextButton = screen.getByText("Next");
       fireEvent.click(nextButton);
-      expect(mockNextStep).toHaveBeenCalledWith({ location: "Paris" });
+      expect(mockNextStep).toHaveBeenCalledWith({ location: "London" });
+    });
+  
+    test("shows dropdown when 'Other Cities' is selected", () => {
+      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      
+      // Initially, dropdown should not be visible
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+      
+      // Click 'Other Cities' radio
+      const otherRadio = screen.getByLabelText("Other Cities");
+      fireEvent.click(otherRadio);
+      
+      // Check if Other Cities is selected
+      expect(otherRadio).toBeChecked();
+      
+      // Check if dropdown appeared
+      const dropdown = screen.getByRole("combobox");
+      expect(dropdown).toBeInTheDocument();
+      
+      // Verify some cities are in the dropdown
+      const options = screen.getAllByRole("option");
+      expect(options.some(option => option.textContent === "Bristol")).toBeTruthy();
+      expect(options.some(option => option.textContent === "Glasgow")).toBeTruthy();
+    });
+  
+    test("selecting a city from dropdown works correctly", () => {
+      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      
+      // Click 'Other Cities' radio to show dropdown
+      fireEvent.click(screen.getByLabelText("Other Cities"));
+      
+      // Select a city from dropdown
+      const dropdown = screen.getByRole("combobox");
+      fireEvent.change(dropdown, { target: { value: "Bristol" } });
+      
+      // Submit form and verify
+      const nextButton = screen.getByText("Next");
+      fireEvent.click(nextButton);
+      expect(mockNextStep).toHaveBeenCalledWith({ location: "Bristol" });
+    });
+  
+    test("radio selection changes when different cities are clicked", () => {
+      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
+      
+      // Click London
+      const londonRadio = screen.getByLabelText("London");
+      fireEvent.click(londonRadio);
+      expect(londonRadio).toBeChecked();
+      
+      // Click Manchester
+      const manchesterRadio = screen.getByLabelText("Manchester");
+      fireEvent.click(manchesterRadio);
+      expect(manchesterRadio).toBeChecked();
+      expect(londonRadio).not.toBeChecked();
     });
 
-    test("does not call nextStep if input is empty", () => {
-      render(
-        <LocationInput formData={{ location: "" }} nextStep={mockNextStep} />,
-      );
+    test("does not call nextStep if no location is selected", () => {
+      render(<LocationInput formData={{ location: "" }} nextStep={mockNextStep} />);
       const nextButton = screen.getByText("Next");
       fireEvent.click(nextButton);
       expect(mockNextStep).not.toHaveBeenCalled();
     });
 
-    test("updates input value when formData changes", () => {
+    test("updates selected location when formData changes", () => {
       const { rerender } = render(
-        <LocationInput formData={formData} nextStep={mockNextStep} />,
+        <LocationInput formData={{ location: "London" }} nextStep={mockNextStep} />
       );
-      const input = screen.getByPlaceholderText("Enter a location...");
-      expect(input.value).toBe("London");
-      const updatedFormData = { location: "New York" };
+      
+      // Initial London radio should be checked
+      expect(screen.getByLabelText("London")).toBeChecked();
+      
+      // Update formData to Manchester
       rerender(
-        <LocationInput formData={updatedFormData} nextStep={mockNextStep} />,
+        <LocationInput formData={{ location: "Manchester" }} nextStep={mockNextStep} />
       );
-      expect(input.value).toBe("New York");
+      
+      // Manchester radio should now be checked
+      expect(screen.getByLabelText("Manchester")).toBeChecked();
+      expect(screen.getByLabelText("London")).not.toBeChecked();
     });
   });
 });


### PR DESCRIPTION
Resolves #67 

ORIGINAL ISSUE: The app's location field was an input, meaning the user could literally put any text in there at all. This needed to be scoped way down to just UK cities as this is manageable to the scope of the app of rnow.

FIXES:

- Location Input is now:
+ Desktop - Radio buttons of popular UK cities, with an 'Other Cities' radio, which when clicked reveals a dropdown of all major UK cities
+ Mobile - Only the dropdown of all major UK cities are visible (implemented for a better UX experience compared to radio buttons clunking up the UI)

DESKTOP:

<img width="913" alt="Screenshot 2024-11-28 at 13 40 01" src="https://github.com/user-attachments/assets/54d8e658-2228-4fe5-b616-7ee95ff3df15">

MOBILE:

<img width="455" alt="Screenshot 2024-11-28 at 13 40 24" src="https://github.com/user-attachments/assets/42744915-f302-440c-9c58-b453947c5a5f">

